### PR TITLE
Hack Request - Remove Insane amount of posts in SNES

### DIFF
--- a/GUI/94Hacks/Program.cs
+++ b/GUI/94Hacks/Program.cs
@@ -85,7 +85,7 @@ namespace Snes94Hacks
                     })
                     .AddChoiceGroup("General", new[]
                     {
-                            "Def. Control ON", "Show 30 Second Periods", "Real Time Clock"                            
+                            "Def. Control ON", "Show 30 Second Periods", "Real Time Clock", "Disable Goal Posts"                            
                     })
                     .AddChoiceGroup("New Functionality", new[]
                     {
@@ -139,7 +139,7 @@ namespace Snes94Hacks
                  }));
             #endregion
 
-            #region AskPatchROMYesNo
+            #region AskToPatchROMYesNo
             // Ask the user if they want to patch an existing ROM, if the user selects yes then ask for the file path.
             // This is also used to handle cross platform where you can't drag and drop on startup. 
             if (string.IsNullOrEmpty(romPath))
@@ -297,7 +297,10 @@ namespace Snes94Hacks
                     {
                         await FileModifier.UpdateFileAsync(ConfigPaths, "!PenaltyShot", "0");
                     }
-
+                    else if (hack == "Disable Goal Posts")
+                    {
+                        await FileModifier.UpdateFileAsync(ConfigPaths, "!GoalPosts", "0");
+                    }
 
                 }
                 catch (Exception ex)

--- a/NHL94SNES.dizraw
+++ b/NHL94SNES.dizraw
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <ProjectXmlSerializer-Root xmlns:exs="https://extendedxmlserializer.github.io/v2" xmlns:ns1="clr-namespace:Diz.Core.model;assembly=Diz.Core" xmlns:ns2="clr-namespace:Diz.Core.model.snes;assembly=Diz.Core" xmlns:sys="https://extendedxmlserializer.github.io/system" xmlns:ns3="clr-namespace:System.Collections.Generic;assembly=System.Collections" xmlns:ns4="clr-namespace:Diz.Core.export;assembly=Diz.Core" SaveVersion="102" Watermark="DiztinGUIsh" Extra1="" Extra2="" xmlns="clr-namespace:Diz.Core.serialization.xml_serializer;assembly=Diz.Core">
-  <Project AttachedRomFilename="C:\_Personal\NHL94SNESVault\NHL '94 (USA).sfc" InternalRomGameName="NHL '94              " InternalCheckSum="2605868205" CurrentViewOffset="1035088">
+  <Project AttachedRomFilename="C:\_Personal\NHL94SNESVault\NHL '94 (USA).sfc" InternalRomGameName="NHL '94              " InternalCheckSum="2605868205" CurrentViewOffset="987691">
     <LogWriterSettings Format="%label:-22% %code:37%;%pc%|%bytes%|; %comment%" DataPerLine="8" Unlabeled="ShowInPoints" Structure="OneBankPerFile" NewLine="true" OutputExtraWhitespace="true" GenerateFullLine="false" IncludeUnusedLabels="false" PrintLabelSpecificComments="true" RomSizeOverride="-1" FileOrFolderOutPath="DizExport\" OutputToString="false" ErrorFilename="errors.txt" />
     <ProjectSettings exs:member="" BsnesUsageMapImportOnlyChangedUnmarked="true">
       <RomBytesOutputFormatSettings CompressGroupBlock="true" CompressUsingTable1="true" InsertCommentIntoOutputLinesEveryNBytes="2048" />
@@ -12,6 +12,7 @@
         <sys:Item Key="10194482" Value="# of Goalies" />
         <sys:Item Key="10194499" Value="Edit Lines # Of players at positon " />
         <sys:Item Key="10194508" Value="# of Goalies" />
+        <sys:Item Key="10203123" Value="Instant Replay SFXs" />
         <sys:Item Key="10257671" Value="Something to do with Player Stats &amp; Team Roster Screen" />
         <sys:Item Key="10259913" Value="Penalties ON Branck 8DD7" />
         <sys:Item Key="10260470" Value="Penalties On Branch 9002" />
@@ -123,8 +124,19 @@
         <sys:Item Key="10333401" Value="Penalities (3)" />
         <sys:Item Key="10333403" Value="Line Changes (3)" />
         <sys:Item Key="10333405" Value="Goalie Control (2)" />
+        <sys:Item Key="10392112" Value="Load Pucks Vert Velocity (Height)" />
+        <sys:Item Key="10392115" Value="Compare Puck Height to Crossbar Height" />
+        <sys:Item Key="10392118" Value="Puck hit the Crossbar" />
+        <sys:Item Key="10392120" Value="Load Pucks Horz Position to center of net" />
+        <sys:Item Key="10392122" Value="Cmp puck Horz pos to 18 decimal (right post)" />
+        <sys:Item Key="10392125" Value="Puck hit the post" />
+        <sys:Item Key="10392127" Value="Load Pucks Horz Position to center of net" />
+        <sys:Item Key="10392129" Value="Cmp puck Horz pos to (-17) decimal (left post)" />
+        <sys:Item Key="10392132" Value="If Positive then Goal; Else Negative Post" />
+        <sys:Item Key="10392144" Value="Setup Post SFX" />
         <sys:Item Key="10396017" Value="Penalties Off Branch A175" />
         <sys:Item Key="10396560" Value="If zero Branch to A3AD" />
+        <sys:Item Key="10400675" Value="Ref Whistle SFX" />
         <sys:Item Key="10400791" Value="Hijack for one min penalities" />
         <sys:Item Key="10401195" Value="Sub routine to Add Stats, 198Ax = Pen Minutes" />
         <sys:Item Key="10401202" Value="Get Current Number of pen minutes for the player Load into A register" />
@@ -391,6 +403,9 @@
         <sys:Item Key="10356598">
           <Value exs:type="ns1:Label" Name="JoyPad" Comment="" />
         </sys:Item>
+        <sys:Item Key="10358265">
+          <Value exs:type="ns1:Label" Name="PucVertVeloc" Comment="" />
+        </sys:Item>
         <sys:Item Key="10360282">
           <Value exs:type="ns1:Label" Name="PauseScreenActive" Comment="" />
         </sys:Item>
@@ -471,6 +486,12 @@
         </sys:Item>
         <sys:Item Key="10362523">
           <Value exs:type="ns1:Label" Name="IsPenaltyShot" Comment="" />
+        </sys:Item>
+        <sys:Item Key="10392079">
+          <Value exs:type="ns1:Label" Name="jmpToGoalLogic" Comment="" />
+        </sys:Item>
+        <sys:Item Key="10392134">
+          <Value exs:type="ns1:Label" Name="fnPucPostCollision" Comment="" />
         </sys:Item>
         <sys:Item Key="10401929">
           <Value exs:type="ns1:Label" Name=".done" Comment="" />
@@ -27307,7 +27328,7 @@ r 12 U
 +09E
 .09E
 .09E
-+09B
++E9B
 .09B
 .09B
 +09B
@@ -28215,9 +28236,148 @@ r 15 U
 .09B
 +09B
 .09B
-r 110 U
++09B
+.09B
+.09B
++09B
+.09B
+.09B
++09B
+.09B
+.09B
++I9B
+.09B
++09B
+.09B
+.09B
++I9B
+.09B
++09B
+.09B
+.09B
++09B
+.09B
++09B
+.09B
+.09B
++09B
+.09B
+.09B
++I9B
+.09B
+.09B
+.09B
++09B
++C9B
+.C9B
++C9B
+.C9B
+.C9B
++C9B
+.C9B
++K9B
+.C9B
++C9B
+.C9B
++C9B
+.C9B
+.C9B
++09B
+.09B
++09B
++09B
++09B
++09B
+.09B
+.09B
++09B
+.09B
+.09B
++E9B
+.09B
++Y9B
+.09B
++E9B
++09B
+.09B
+.09B
++I9B
+.09B
+.09B
+.09B
++E9B
+.09B
+.09B
++09B
+.09B
+.09B
++09B
+.09B
+.09B
++I9B
+.09B
++09B
+.09B
+.09B
++I9B
+.09B
++09B
+.09B
+.09B
++09B
+.09B
++09B
+.09B
+.09B
++09B
+.09B
+.09B
++I9B
+.09B
+.09B
+.09B
++09B
++C9B
+.C9B
++C9B
+.C9B
+.C9B
++C9B
+.C9B
++K9B
+.C9B
 ;pos=0DB000
-r 31 U
++C9B
+.C9B
++C9B
+.C9B
+.C9B
++09B
+.09B
++09B
++09B
++09B
++09B
+.09B
+.09B
++09B
+.09B
+.09B
++E9B
+.09B
++Y9B
+.09B
++E9B
++09B
+.09B
+.09B
++I9B
+.09B
+.09B
+.09B
++c9B
+.09B
+.09B
 +09B
 .09B
 .09B

--- a/Src/bank_9B.asm
+++ b/Src/bank_9B.asm
@@ -2819,7 +2819,7 @@
                        CMP.W #$001A                         ;9BA050|C91A00  |;
                        BMI CODE_9BA076                      ;9BA053|3021    |;
                        ASL A                                ;9BA055|0A      |;
-                       ADC.W $0DF9                          ;9BA056|6DF90D  |;
+                       ADC.W PucVertVeloc                   ;9BA056|6DF90D  |;
                        CLC                                  ;9BA059|18      |;
                        ADC.W $0DD3                          ;9BA05A|6DD30D  |;
                        CMP.W #$FEB8                         ;9BA05D|C9B8FE  |;
@@ -2836,7 +2836,7 @@
                        CMP.W #$001A                         ;9BA07C|C91A00  |;
                        BMI CODE_9BA076                      ;9BA07F|30F5    |;
                        ASL A                                ;9BA081|0A      |;
-                       ADC.W $0DF9                          ;9BA082|6DF90D  |;
+                       ADC.W PucVertVeloc                   ;9BA082|6DF90D  |;
                        CLC                                  ;9BA085|18      |;
                        ADC.W $0DD3                          ;9BA086|6DD30D  |;
                        CMP.W #$FE98                         ;9BA089|C998FE  |;
@@ -3552,7 +3552,7 @@
                        INX                                  ;9BA9AF|E8      |;
                        DEC.B $AD                            ;9BA9B0|C6AD    |;
                        BPL CODE_9BA985                      ;9BA9B2|10D1    |;
-                       LDA.W $0DF9                          ;9BA9B4|ADF90D  |;
+                       LDA.W PucVertVeloc                   ;9BA9B4|ADF90D  |;
                        STA.W $2180                          ;9BA9B7|8D8021  |;
                        LDA.W $0DFB                          ;9BA9BA|ADFB0D  |;
                        STA.W $2180                          ;9BA9BD|8D8021  |;
@@ -4227,24 +4227,71 @@
                        JSL.L CODE_9BB136                    ;9BAF8B|2236B19B|;
                        LDA.B $C1                            ;9BAF8F|A5C1    |;
                        BEQ CODE_9BAF6E                      ;9BAF91|F0DB    |;
-                       db $AD,$B3,$0C,$29,$FF,$00,$C9,$FF   ;9BAF93|        |;
-                       db $00,$F0,$3A,$C9,$16,$00,$B0,$2D   ;9BAF9B|        |;
-                       db $AD,$B7,$0C,$85,$64,$AD,$B3,$0C   ;9BAFA3|        |;
-                       db $29,$FF,$00,$22,$7D,$A1,$80,$A8   ;9BAFAB|        |;
-                       db $E2,$20,$B9,$F2,$08,$C9,$02,$D0   ;9BAFB3|        |;
-                       db $10,$A9,$03,$99,$F2,$08,$C2,$20   ;9BAFBB|        |;
-                       db $98,$0A,$A8,$AD,$B5,$0C,$99,$4A   ;9BAFC3|        |;
-                       db $09,$C2,$20,$80,$08,$38,$E9,$15   ;9BAFCB|        |;
-                       db $00,$22,$7F,$9A,$9C,$AD,$AD,$0C   ;9BAFD3|        |;
-                       db $29,$FF,$00,$C9,$FF,$00,$F0,$3A   ;9BAFDB|        |;
-                       db $C9,$16,$00,$B0,$2D,$AD,$B1,$0C   ;9BAFE3|        |;
-                       db $85,$64,$AD,$AD,$0C,$29,$FF,$00   ;9BAFEB|        |;
-                       db $22,$7D,$A1,$80,$A8,$E2,$20,$B9   ;9BAFF3|        |;
-                       db $F2,$08,$C9,$02,$D0,$10,$A9,$03   ;9BAFFB|        |;
-                       db $99,$F2,$08,$C2,$20,$98,$0A,$A8   ;9BB003|        |;
-                       db $AD,$AF,$0C,$99,$4A,$09,$C2,$20   ;9BB00B|        |;
-                       db $80,$08,$38,$E9,$15,$00,$22,$7F   ;9BB013|        |;
-                       db $9A,$9C,$4C,$AB,$AB               ;9BB01B|        |;
+                       LDA.W $0CB3                          ;9BAF93|ADB30C  |;
+                       AND.W #$00FF                         ;9BAF96|29FF00  |;
+                       CMP.W #$00FF                         ;9BAF99|C9FF00  |;
+                       BEQ CODE_9BAFD8                      ;9BAF9C|F03A    |;
+                       CMP.W #$0016                         ;9BAF9E|C91600  |;
+                       BCS CODE_9BAFD0                      ;9BAFA1|B02D    |;
+                       LDA.W $0CB7                          ;9BAFA3|ADB70C  |;
+                       STA.B $64                            ;9BAFA6|8564    |;
+                       LDA.W $0CB3                          ;9BAFA8|ADB30C  |;
+                       AND.W #$00FF                         ;9BAFAB|29FF00  |;
+                       JSL.L fn_PlaySFX                     ;9BAFAE|227DA180|;
+                       TAY                                  ;9BAFB2|A8      |;
+                       SEP #$20                             ;9BAFB3|E220    |;
+                       LDA.W $08F2,Y                        ;9BAFB5|B9F208  |;
+                       CMP.B #$02                           ;9BAFB8|C902    |;
+                       BNE CODE_9BAFCC                      ;9BAFBA|D010    |;
+                       LDA.B #$03                           ;9BAFBC|A903    |;
+                       STA.W $08F2,Y                        ;9BAFBE|99F208  |;
+                       REP #$20                             ;9BAFC1|C220    |;
+                       TYA                                  ;9BAFC3|98      |;
+                       ASL A                                ;9BAFC4|0A      |;
+                       TAY                                  ;9BAFC5|A8      |;
+                       LDA.W $0CB5                          ;9BAFC6|ADB50C  |;
+                       STA.W $094A,Y                        ;9BAFC9|994A09  |;
+          CODE_9BAFCC:
+                       REP #$20                             ;9BAFCC|C220    |;
+                       BRA CODE_9BAFD8                      ;9BAFCE|8008    |;
+          CODE_9BAFD0:
+                       SEC                                  ;9BAFD0|38      |;
+                       SBC.W #$0015                         ;9BAFD1|E91500  |;
+                       JSL.L CODE_9C9A7F                    ;9BAFD4|227F9A9C|;
+          CODE_9BAFD8:
+                       LDA.W $0CAD                          ;9BAFD8|ADAD0C  |;
+                       AND.W #$00FF                         ;9BAFDB|29FF00  |;
+                       CMP.W #$00FF                         ;9BAFDE|C9FF00  |;
+                       BEQ CODE_9BB01D                      ;9BAFE1|F03A    |;
+                       CMP.W #$0016                         ;9BAFE3|C91600  |;
+                       BCS CODE_9BB015                      ;9BAFE6|B02D    |;
+                       LDA.W $0CB1                          ;9BAFE8|ADB10C  |;
+                       STA.B $64                            ;9BAFEB|8564    |;
+                       LDA.W $0CAD                          ;9BAFED|ADAD0C  |;
+                       AND.W #$00FF                         ;9BAFF0|29FF00  |;
+                       JSL.L fn_PlaySFX                     ;9BAFF3|227DA180|; Instant Replay SFXs
+                       TAY                                  ;9BAFF7|A8      |;
+                       SEP #$20                             ;9BAFF8|E220    |;
+                       LDA.W $08F2,Y                        ;9BAFFA|B9F208  |;
+                       CMP.B #$02                           ;9BAFFD|C902    |;
+                       BNE CODE_9BB011                      ;9BAFFF|D010    |;
+                       LDA.B #$03                           ;9BB001|A903    |;
+                       STA.W $08F2,Y                        ;9BB003|99F208  |;
+                       REP #$20                             ;9BB006|C220    |;
+                       TYA                                  ;9BB008|98      |;
+                       ASL A                                ;9BB009|0A      |;
+                       TAY                                  ;9BB00A|A8      |;
+                       LDA.W $0CAF                          ;9BB00B|ADAF0C  |;
+                       STA.W $094A,Y                        ;9BB00E|994A09  |;
+          CODE_9BB011:
+                       REP #$20                             ;9BB011|C220    |;
+                       BRA CODE_9BB01D                      ;9BB013|8008    |;
+          CODE_9BB015:
+                       SEC                                  ;9BB015|38      |;
+                       SBC.W #$0015                         ;9BB016|E91500  |;
+                       JSL.L CODE_9C9A7F                    ;9BB019|227F9A9C|;
+          CODE_9BB01D:
+                       JMP.W CODE_9BABAB                    ;9BB01D|4CABAB  |;
  
           CODE_9BB020:
                        LDA.W #$000F                         ;9BB020|A90F00  |;

--- a/Src/bank_9E.asm
+++ b/Src/bank_9E.asm
@@ -1924,10 +1924,10 @@
           CODE_9E8E91:
                        CPX.W #$001C                         ;9E8E91|E01C00  |;
                        BNE CODE_9E8E8B                      ;9E8E94|D0F5    |;
-                       LDA.W $0DF9                          ;9E8E96|ADF90D  |;
+                       LDA.W PucVertVeloc                   ;9E8E96|ADF90D  |;
                        CMP.W #$0021                         ;9E8E99|C92100  |;
                        BPL UNREACH_9E8E8E                   ;9E8E9C|10F0    |;
-                       LDA.W $0DF9                          ;9E8E9E|ADF90D  |;
+                       LDA.W PucVertVeloc                   ;9E8E9E|ADF90D  |;
                        CMP.W #$0016                         ;9E8EA1|C91600  |;
                        BCC CODE_9E8E8B                      ;9E8EA4|90E5    |;
                        db $AD,$D3,$0D,$C9,$12,$01,$30,$E0   ;9E8EA6|        |;
@@ -2022,7 +2022,7 @@
                        STA.B $A5                            ;9E8FCB|85A5    |;
                        JSL.L CODE_9EDE5E                    ;9E8FCD|225EDE9E|;
                        LDA.W #$000A                         ;9E8FD1|A90A00  |;
-                       LDY.W $0DF9                          ;9E8FD4|ACF90D  |;
+                       LDY.W PucVertVeloc                   ;9E8FD4|ACF90D  |;
                        CPY.W #$000B                         ;9E8FD7|C00B00  |;
                        BCS CODE_9E8FDF                      ;9E8FDA|B003    |;
                        LDA.W #$0004                         ;9E8FDC|A90400  |;
@@ -2154,7 +2154,7 @@
                        BEQ CODE_9E9116                      ;9E90BE|F056    |;
  
           CODE_9E90C0:
-                       LDA.W $0DF9                          ;9E90C0|ADF90D  |;
+                       LDA.W PucVertVeloc                   ;9E90C0|ADF90D  |;
                        CMP.W #$000D                         ;9E90C3|C90D00  |;
                        BPL CODE_9E9116                      ;9E90C6|104E    |;
                        LDY.B zpCurntTeamLoopVal             ;9E90C8|A491    |;
@@ -2305,7 +2305,7 @@
           CODE_9E920C:
                        JMP.W CODE_9E8F42                    ;9E920C|4C428F  |;
  
-          CODE_9E920F:
+       jmpToGoalLogic:
                        JMP.W CODE_9EF319                    ;9E920F|4C19F3  |;
  
           CODE_9E9212:
@@ -2323,21 +2323,21 @@
                        STA.B $A5                            ;9E9229|85A5    |;
                        LDA.W $14DF                          ;9E922B|ADDF14  |;
                        BNE CODE_9E91EC                      ;9E922E|D0BC    |;
-                       LDA.W $0DF9                          ;9E9230|ADF90D  |;
-                       CMP.W #$000D                         ;9E9233|C90D00  |;
-                       BEQ CODE_9E9246                      ;9E9236|F00E    |;
-                       LDA.B $AD                            ;9E9238|A5AD    |;
-                       CMP.W #$0012                         ;9E923A|C91200  |;
-                       BPL CODE_9E9246                      ;9E923D|1007    |;
-                       LDA.B $AD                            ;9E923F|A5AD    |;
-                       CMP.W #$FFEF                         ;9E9241|C9EFFF  |;
-                       BPL CODE_9E920F                      ;9E9244|10C9    |;
+                       LDA.W PucVertVeloc                   ;9E9230|ADF90D  |; Load Pucks Vert Velocity (Height)
+                       CMP.W #$000D                         ;9E9233|C90D00  |; Compare Puck Height to Crossbar Height
+                       BEQ fnPucPostCollision               ;9E9236|F00E    |; Puck hit the Crossbar
+                       LDA.B $AD                            ;9E9238|A5AD    |; Load Pucks Horz Position to center of net
+                       CMP.W #$0012                         ;9E923A|C91200  |; Cmp puck Horz pos to 18 decimal (right post)
+                       BPL fnPucPostCollision               ;9E923D|1007    |; Puck hit the post
+                       LDA.B $AD                            ;9E923F|A5AD    |; Load Pucks Horz Position to center of net
+                       CMP.W #$FFEF                         ;9E9241|C9EFFF  |; Cmp puck Horz pos to (-17) decimal (left post)
+                       BPL jmpToGoalLogic                   ;9E9244|10C9    |; If Positive then Goal; Else Negative Post
  
-          CODE_9E9246:
+   fnPucPostCollision:
                        JSL.L CODE_9EF213                    ;9E9246|2213F29E|;
                        STZ.W BreakAwayActive_flg            ;9E924A|9C8B1E  |;
                        STZ.W OneTimerFlg                    ;9E924D|9C891E  |;
-                       LDA.W #$0009                         ;9E9250|A90900  |;
+                       LDA.W #$0009                         ;9E9250|A90900  |; Setup Post SFX
                        JSL.L CODE_9C9ABC                    ;9E9253|22BC9A9C|;
                        LDA.L $7E35E0                        ;9E9257|AFE0357E|;
                        CLC                                  ;9E925B|18      |;
@@ -2952,7 +2952,7 @@
                        BRA CODE_9E976E                      ;9E9786|80E6    |;
  
           CODE_9E9788:
-                       LDA.W $0DF9                          ;9E9788|ADF90D  |;
+                       LDA.W PucVertVeloc                   ;9E9788|ADF90D  |;
                        SEC                                  ;9E978B|38      |;
                        SBC.W #$0010                         ;9E978C|E91000  |;
                        BPL CODE_9E97DC                      ;9E978F|104B    |;
@@ -3037,7 +3037,7 @@
                        BNE CODE_9E97F7                      ;9E9814|D0E1    |;
                        LDA.W $0F43,Y                        ;9E9816|B9430F  |;
                        BEQ CODE_9E97FA                      ;9E9819|F0DF    |;
-                       LDA.W $0DF9                          ;9E981B|ADF90D  |;
+                       LDA.W PucVertVeloc                   ;9E981B|ADF90D  |;
                        CMP.W #$0005                         ;9E981E|C90500  |;
                        BPL CODE_9E97F7                      ;9E9821|10D4    |;
                        LDA.W $0E01                          ;9E9823|AD010E  |;
@@ -3262,13 +3262,13 @@
                        LDA.W #$0005                         ;9E99FA|A90500  |;
  
           CODE_9E99FD:
-                       CMP.W $0DF9                          ;9E99FD|CDF90D  |;
+                       CMP.W PucVertVeloc                   ;9E99FD|CDF90D  |;
                        BCC CODE_9E9A0E                      ;9E9A00|900C    |;
                        LDA.B $B1                            ;9E9A02|A5B1    |;
                        SEC                                  ;9E9A04|38      |;
                        SBC.B $B5                            ;9E9A05|E5B5    |;
                        BMI CODE_9E9A11                      ;9E9A07|3008    |;
-                       CMP.W $0DF9                          ;9E9A09|CDF90D  |;
+                       CMP.W PucVertVeloc                   ;9E9A09|CDF90D  |;
                        BCC CODE_9E9A11                      ;9E9A0C|9003    |;
  
           CODE_9E9A0E:
@@ -6264,7 +6264,7 @@
           CODE_9EB39E:
                        LDA.W #$7000                         ;9EB39E|A90070  |;
                        STA.B $64                            ;9EB3A1|8564    |;
-                       LDA.W #$0015                         ;9EB3A3|A91500  |;
+                       LDA.W #$0015                         ;9EB3A3|A91500  |; Ref Whistle SFX
                        JSL.L fn_PlaySFX                     ;9EB3A6|227DA180|;
                        STZ.W $1620                          ;9EB3AA|9C2016  |;
                        LDA.W #$0004                         ;9EB3AD|A90400  |;
@@ -10699,7 +10699,7 @@ fn_end_cpu_pull_goalie_3rdperiod:
           CODE_9ED9C5:
                        CMP.W #$0002                         ;9ED9C5|C90200  |;
                        BCS CODE_9ED987                      ;9ED9C8|B0BD    |;
-                       LDA.W $0DF9                          ;9ED9CA|ADF90D  |;
+                       LDA.W PucVertVeloc                   ;9ED9CA|ADF90D  |;
                        SEC                                  ;9ED9CD|38      |;
                        SBC.W #$0008                         ;9ED9CE|E90800  |;
                        BPL CODE_9EDA04                      ;9ED9D1|1031    |;
@@ -11187,7 +11187,7 @@ fn_end_cpu_pull_goalie_3rdperiod:
           CODE_9EDDBD:
                        LDA.W $0E01                          ;9EDDBD|AD010E  |;
                        AND.W #$FF00                         ;9EDDC0|2900FF  |;
-                       ORA.W $0DF9                          ;9EDDC3|0DF90D  |;
+                       ORA.W PucVertVeloc                   ;9EDDC3|0DF90D  |;
                        BEQ CODE_9EDDCB                      ;9EDDC6|F003    |;
                        JMP.W CODE_9E9788                    ;9EDDC8|4C8897  |;
  
@@ -13365,7 +13365,7 @@ fn_end_cpu_pull_goalie_3rdperiod:
                        RTL                                  ;9EEF7E|6B      |;
  
           CODE_9EEF7F:
-                       LDA.W $0DF9                          ;9EEF7F|ADF90D  |;
+                       LDA.W PucVertVeloc                   ;9EEF7F|ADF90D  |;
                        CMP.W #$0008                         ;9EEF82|C90800  |;
                        BPL CODE_9EEF91                      ;9EEF85|100A    |;
                        LDA.B $A5                            ;9EEF87|A5A5    |;
@@ -13375,7 +13375,7 @@ fn_end_cpu_pull_goalie_3rdperiod:
  
           CODE_9EEF91:
                        JSL.L CODE_9EC4F3                    ;9EEF91|22F3C49E|;
-                       LDY.W $0DF9                          ;9EEF95|ACF90D  |;
+                       LDY.W PucVertVeloc                   ;9EEF95|ACF90D  |;
                        CMP.W #$000E                         ;9EEF98|C90E00  |;
                        BMI CODE_9EEFA6                      ;9EEF9B|3009    |;
                        db $A9,$05,$00,$22,$7F,$9A,$9C,$80   ;9EEF9D|        |;
@@ -13412,7 +13412,7 @@ fn_end_cpu_pull_goalie_3rdperiod:
                        STA.W $0EE4,X                        ;9EEFE4|9DE40E  |;
                        REP #$30                             ;9EEFE7|C230    |;
                        JSL.L CODE_9EDE5E                    ;9EEFE9|225EDE9E|;
-                       LDA.W $0DF9                          ;9EEFED|ADF90D  |;
+                       LDA.W PucVertVeloc                   ;9EEFED|ADF90D  |;
                        CMP.W #$0008                         ;9EEFF0|C90800  |;
                        BMI CODE_9EF02A                      ;9EEFF3|3035    |;
                        LDA.B $AD                            ;9EEFF5|A5AD    |;
@@ -13435,7 +13435,7 @@ fn_end_cpu_pull_goalie_3rdperiod:
                        STA.B $AF                            ;9EF018|85AF    |;
                        CMP.W #$0900                         ;9EF01A|C90009  |;
                        BCC CODE_9EF02B                      ;9EF01D|900C    |;
-                       LDA.W $0DF9                          ;9EF01F|ADF90D  |;
+                       LDA.W PucVertVeloc                   ;9EF01F|ADF90D  |;
                        CMP.W #$000C                         ;9EF022|C90C00  |;
                        BMI CODE_9EF02A                      ;9EF025|3003    |;
                        JMP.W CODE_9E9B52                    ;9EF027|4C529B  |;
@@ -13463,7 +13463,7 @@ fn_end_cpu_pull_goalie_3rdperiod:
  
           CODE_9EF04D:
                        STZ.B $AD                            ;9EF04D|64AD    |;
-                       LDA.W $0DF9                          ;9EF04F|ADF90D  |;
+                       LDA.W PucVertVeloc                   ;9EF04F|ADF90D  |;
                        CMP.W #$0008                         ;9EF052|C90800  |;
                        BPL CODE_9EF05B                      ;9EF055|1004    |;
                        INC.B $AD                            ;9EF057|E6AD    |;
@@ -14110,7 +14110,7 @@ fn_end_cpu_pull_goalie_3rdperiod:
                        STY.W $0DD3                          ;9EF578|8CD30D  |;
                        LDA.W #$0600                         ;9EF57B|A90006  |;
                        STA.W $0E01                          ;9EF57E|8D010E  |;
-                       STZ.W $0DF9                          ;9EF581|9CF90D  |;
+                       STZ.W PucVertVeloc                   ;9EF581|9CF90D  |;
                        LDA.W #$FFFF                         ;9EF584|A9FFFF  |;
                        STA.W $0D19                          ;9EF587|8D190D  |;
                        STA.W $0D1D                          ;9EF58A|8D1D0D  |;

--- a/Src/bank_9F.asm
+++ b/Src/bank_9F.asm
@@ -684,7 +684,7 @@ Real_Time_Pen_Clock_2:
                        STA.W $17B0                          ;9F8692|8DB017  |;
                        STA.W $17B2                          ;9F8695|8DB217  |;
                        STA.W $17B4                          ;9F8698|8DB417  |;
-                       LDA.W $0DF9                          ;9F869B|ADF90D  |;
+                       LDA.W PucVertVeloc                   ;9F869B|ADF90D  |;
                        STA.W $0DFF                          ;9F869E|8DFF0D  |;
                        LDX.W #$001E                         ;9F86A1|A21E00  |;
  
@@ -786,7 +786,7 @@ Real_Time_Pen_Clock_2:
           CODE_9F8755:
                        CPX.W #$001C                         ;9F8755|E01C00  |;
                        BNE CODE_9F875F                      ;9F8758|D005    |;
-                       LDA.W $0DF9                          ;9F875A|ADF90D  |;
+                       LDA.W PucVertVeloc                   ;9F875A|ADF90D  |;
                        BNE CODE_9F8796                      ;9F875D|D037    |;
  
           CODE_9F875F:
@@ -848,7 +848,7 @@ Real_Time_Pen_Clock_2:
           CODE_9F87D9:
                        CPX.W #$001C                         ;9F87D9|E01C00  |;
                        BNE CODE_9F8834                      ;9F87DC|D056    |;
-                       LDA.W $0DF9                          ;9F87DE|ADF90D  |;
+                       LDA.W PucVertVeloc                   ;9F87DE|ADF90D  |;
                        BMI CODE_9F8834                      ;9F87E1|3051    |;
                        BNE CODE_9F87EA                      ;9F87E3|D005    |;
                        LDA.W $0E01                          ;9F87E5|AD010E  |;
@@ -868,10 +868,10 @@ Real_Time_Pen_Clock_2:
                        ADC.W $0DFD                          ;9F8801|6DFD0D  |;
                        STA.W $0DFD                          ;9F8804|8DFD0D  |;
                        LDA.B $0A                            ;9F8807|A50A    |;
-                       ADC.W $0DF9                          ;9F8809|6DF90D  |;
-                       STA.W $0DF9                          ;9F880C|8DF90D  |;
+                       ADC.W PucVertVeloc                   ;9F8809|6DF90D  |;
+                       STA.W PucVertVeloc                   ;9F880C|8DF90D  |;
                        BPL CODE_9F8834                      ;9F880F|1023    |;
-                       STZ.W $0DF9                          ;9F8811|9CF90D  |;
+                       STZ.W PucVertVeloc                   ;9F8811|9CF90D  |;
                        STZ.W $0DFD                          ;9F8814|9CFD0D  |;
                        LDA.W $0E01                          ;9F8817|AD010E  |;
                        EOR.W #$FFFF                         ;9F881A|49FFFF  |;
@@ -973,7 +973,7 @@ Real_Time_Pen_Clock_2:
                        BEQ CODE_9F88F6                      ;9F88D9|F01B    |;
  
           CODE_9F88DB:
-                       LDA.W $0DF9                          ;9F88DB|ADF90D  |;
+                       LDA.W PucVertVeloc                   ;9F88DB|ADF90D  |;
                        CMP.W #$000D                         ;9F88DE|C90D00  |;
                        BCS CODE_9F88F6                      ;9F88E1|B013    |;
                        LDA.W $0EFF                          ;9F88E3|ADFF0E  |;
@@ -1229,7 +1229,7 @@ Real_Time_Pen_Clock_2:
                        JMP.W CODE_9F8947                    ;9F8AE7|4C4789  |;
  
           CODE_9F8AEA:
-                       LDA.W $0DF9                          ;9F8AEA|ADF90D  |;
+                       LDA.W PucVertVeloc                   ;9F8AEA|ADF90D  |;
                        CMP.W #$0018                         ;9F8AED|C91800  |;
                        BCS CODE_9F8B24                      ;9F8AF0|B032    |;
                        LDA.W $0D71                          ;9F8AF2|AD710D  |;
@@ -1248,7 +1248,7 @@ Real_Time_Pen_Clock_2:
                        db $0D                               ;9F8B23|        |;
  
           CODE_9F8B24:
-                       LDA.W $0DF9                          ;9F8B24|ADF90D  |;
+                       LDA.W PucVertVeloc                   ;9F8B24|ADF90D  |;
                        BNE CODE_9F8B58                      ;9F8B27|D02F    |;
                        LDA.W $0DD3                          ;9F8B29|ADD30D  |;
                        CMP.W #$FEC2                         ;9F8B2C|C9C2FE  |;
@@ -3875,7 +3875,7 @@ Real_Time_Pen_Clock_2:
                        STA.W $162A                          ;9FA921|8D2A16  |;
                        STA.W $0D19                          ;9FA924|8D190D  |;
                        STA.W $0D1D                          ;9FA927|8D1D0D  |;
-                       STA.W $0DF9                          ;9FA92A|8DF90D  |;
+                       STA.W PucVertVeloc                   ;9FA92A|8DF90D  |;
                        STA.W $0D07                          ;9FA92D|8D070D  |;
                        ASL A                                ;9FA930|0A      |;
                        STA.W $0AD9                          ;9FA931|8DD90A  |;
@@ -4630,7 +4630,7 @@ Real_Time_Pen_Clock_2:
           CODE_9FAFBE:
                        STZ.W $0D71                          ;9FAFBE|9C710D  |;
                        STZ.W $0DD3                          ;9FAFC1|9CD30D  |;
-                       STZ.W $0DF9                          ;9FAFC4|9CF90D  |;
+                       STZ.W PucVertVeloc                   ;9FAFC4|9CF90D  |;
                        STZ.W $0EDF                          ;9FAFC7|9CDF0E  |;
                        STZ.W $0EFF                          ;9FAFCA|9CFF0E  |;
                        STZ.W $0E01                          ;9FAFCD|9C010E  |;
@@ -4866,7 +4866,7 @@ Real_Time_Pen_Clock_2:
                        JSL.L CODE_808658                    ;9FB1C5|22588680|;
                        AND.W #$07FF                         ;9FB1C9|29FF07  |;
                        STA.W $0E01                          ;9FB1CC|8D010E  |;
-                       STZ.W $0DF9                          ;9FB1CF|9CF90D  |;
+                       STZ.W PucVertVeloc                   ;9FB1CF|9CF90D  |;
                        STZ.W $1563,X                        ;9FB1D2|9E6315  |;
                        LDA.W #$0018                         ;9FB1D5|A91800  |;
                        STA.B $A5                            ;9FB1D8|85A5    |;

--- a/Src/config.asm
+++ b/Src/config.asm
@@ -24,6 +24,11 @@
 !PenaltyShot = 1   ; Enable = 1,  Disable = 0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;Enable / Disable Puck Hitting Goal Post
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+!GoalPosts = 1   ; Enable = 1,  Disable = 0
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;Enable Pull Goalie With L+R Trigger
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 !Manual_Pull_Goalie = 0     ; Enable = 1,  Disable = 0

--- a/Src/labels-all.asm
+++ b/Src/labels-all.asm
@@ -48,4 +48,5 @@
                        CODE_80A17D = $80A17D
                        Set_Default_Goalie = $9FC6B2
                        CODE_9EBA67 = $9EBA67
-                       CODE_9EC06D = $9EC06D 
+                       CODE_9EC06D = $9EC06D
+                       jmpToGoalLogic = $9E920F

--- a/Src/labels.asm
+++ b/Src/labels.asm
@@ -6,6 +6,7 @@
                        PenaltiesOnOff = $7E34C4
                        CurntTeamLoopVal = $9E0091; !^ 00 Home 02 Away ^!
                        JoyPad = $9E0776
+                       PucVertVeloc = $9E0DF9
                        PauseScreenActive = $9E15DA
                        period = $9E1630
                        clock_remaining_time = $9E1632

--- a/Src/patches.asm
+++ b/Src/patches.asm
@@ -6,4 +6,4 @@
                        incsrc "patches/OneMinutePenalties.asm"
                        incsrc "patches/DefControl.asm"
                        incsrc "patches/PenaltyShot.asm"
-                       
+                       incsrc "patches/DisablePosts.asm"                      

--- a/Src/patches/DisablePosts.asm
+++ b/Src/patches/DisablePosts.asm
@@ -1,0 +1,10 @@
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;Disable Goal Posts Patch
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+    if  !GoalPosts  == 0
+        
+            org $9E9236         ;JMP to Goal Logic
+            JMP jmpToGoalLogic
+
+            print "Goal Posts Disabled"
+    endif


### PR DESCRIPTION
Fixes #43
Documented Horz Puck Veloc.
Added Patch to bypass checking of puck hitting posts.
Updated GUI to apply the patch.